### PR TITLE
Set backlight to hard coded intensity on wakeup (and set repeatedly) for macOS High Sierra

### DIFF
--- a/AMDGPUWakeHandler/AMDGPUWakeHandler.cpp
+++ b/AMDGPUWakeHandler/AMDGPUWakeHandler.cpp
@@ -64,17 +64,40 @@ void AMDGPUWakeHandler::stop(IOService *provider)
 void AMDGPUWakeHandler::disableGPU()
 {
     IOLog("Disabling GPU\n");
+    // GMUX_PORT_SWITCH_DDC - 1=IGD, 2=DIS
     outb(0x728, 0x1);
+    // GMUX_PORT_SWITCH_DISPLAY - 2=IGD, 3=DIS
     outb(0x710, 0x2);
+    // GMUX_PORT_SWITCH_EXTERNAL - 2=IGD, 3=DIS
     outb(0x740, 0x2);
+    // GMUX_PORT_DISCRETE_POWER - 0-3?
     outb(0x750, 0x0);
 }
+
+void AMDGPUWakeHandler::setBacklight(uint32_t Intensity)
+{
+    IOLog("Setting backlight to %u\n", Intensity);
+    // Write to GMUX_PORT_BRIGHTNESS -> GMUX_PORT_BRIGHTNESS+3
+    outb(0x774, Intensity & 0xff);
+    outb(0x775, (Intensity >> 8) & 0xff);
+    outb(0x776, (Intensity >> 16) & 0xff);
+    outb(0x777, (Intensity >> 24) & 0xff);
+}
+
+// Wakeup backlight intensity
+#define BacklightIntensity 120000
 
 IOReturn AMDGPUWakeHandler::setPowerState ( unsigned long whichState, IOService * whatDevice )
 {
     if ( kIOPMPowerOff != whichState ) {
         IOLog("Waking up\n");
-        this->disableGPU();
+        // Disable GPU and set backlight several times after wakeup to make sure it sticks
+        // (and we aren't overruled by another driver?)
+        for(int i = 0; i < 20; i++){
+            this->disableGPU();
+            this->setBacklight(BacklightIntensity);
+            IOSleep(500);
+        }
     }
     return kIOPMAckImplied;
 }

--- a/AMDGPUWakeHandler/AMDGPUWakeHandler.hpp
+++ b/AMDGPUWakeHandler/AMDGPUWakeHandler.hpp
@@ -13,4 +13,5 @@ public:
     virtual IOReturn setPowerState(unsigned long whichState, IOService * whatDevice);
 private:
     virtual void disableGPU();
+    virtual void setBacklight(uint32_t Intensity);
 };


### PR DESCRIPTION
I have added a dirty hack in my fork of AMDGPUWakeHandler to force the backlight intensity on wakeup for macOS High Sierra. Setting the intensity once didn't work - I assume something else is resetting it after we tried. There's a dirty 10 second loop in there which sets the intensity every 0.5 seconds.